### PR TITLE
Point all imports to `src/index.ts`

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "url": "https://github.com/react-native-community/react-native-svg"
   },
   "license": "MIT",
-  "main": "lib/commonjs/index.js",
-  "module": "lib/module/index.js",
+  "main": "src/index.ts",
+  "module": "src/index.ts",
   "react-native": "src/index.ts",
   "types": "src/index.d.ts",
   "files": [


### PR DESCRIPTION
After removing `prepare` step some tools can not import files from
`react-native-svg` because `lib/*` does not exist
